### PR TITLE
OD-1251 override extract command to workaround zip bug

### DIFF
--- a/manifests/mongodb_exporter.pp
+++ b/manifests/mongodb_exporter.pp
@@ -125,5 +125,6 @@ class prometheus::mongodb_exporter (
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
     scrape_job_labels  => $scrape_job_labels,
+    archive_bin_path   => '/opt/mongodb_exporter',
   }
 }


### PR DESCRIPTION
@kuldazbraslav I wish to submit this PR as a somewhat ham-fisted solution to getting the mongodb_exporter to deploy and work correctly.

To explain why this change is necessary, we need to identify the change in behaviour of the tar.gz files provided by the [Percona repository](https://github.com/percona/mongodb_exporter/releases/). Prior to 0.3.1 (I still don't know why the module defaults to this version), running the `tar xzf %s` command (default archive [resource](https://github.com/voxpupuli/puppet-archive#extract-customization) behaviour) will create a new directory (/opt/mongodb_exporter) and extract the contents into it (So that the binary is located at `/opt/mongodb_exporter/mongodb_exporter`). This directory would be created neatly in the /opt directory for further processing to take place.

Later versions such as 0.7.0, which I was testing before you asked me to reimplement the exporter using this module, appear to extract the files in the current working directory (/tmp in this case). Unaware that the folder is no longer created, the module attempts to copy the binary into the /opt directory, then proceeds to symlink the bin_link to the non-existent /opt/mongodb_exporter/ directory. As a result the service fails to start, and metrics are not exported.

To overcome this, I have attempted to override `archive_bin_path` to point directly to the binary as it is exported during normal processing. I have previously attempted to solve the problem by moving some calling variables around in the puppet6 repo with no success. As far as I am aware, the problem must be solved within this repository.

I have tried using the latest version of the prometheus module from the forge with no success.

If we accept this patch, we will need to be aware that a change in untar behaviour from the Percona release directory could break this. We would only need to worry about it if we update the version of mongodb_exporter to be used.